### PR TITLE
DO-1215 / Enable Trivy vulnerability scanning

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -251,10 +251,16 @@ jobs:
       
       # ## image scanning
       - if: inputs.enable_trivy == 'true'
+        name: Generate tarball from image
+        run: |
+          docker pull ${{ inputs.image_registry }}/${{ inputs.image_organization }}/${{ inputs.image_name }}:${{ inputs.tag }}
+          docker save -o vuln-image.tar ${{ inputs.image_registry }}/${{ inputs.image_organization }}/${{ inputs.image_name }}:${{ inputs.tag }}
+          
+      - if: inputs.enable_trivy == 'true'
         name: Run Trivy vulnerability scanner
         uses: aquasecurity/trivy-action@master
         with:
-          image-ref: '${{ inputs.image_registry }}/${{ inputs.image_organization }}/${{ inputs.image_name }}:${{ inputs.tag }}'
+          input: /github/workspace/vuln-image.tar
           format: 'sarif'
           output: 'trivy-results.sarif'
           exit-code: '0'
@@ -262,7 +268,7 @@ jobs:
           vuln-type: 'os,library'
           severity: 'CRITICAL,HIGH'
         env:
-          GOOGLE_APPLICATION_CREDENTIALS: ${{ steps.auth.outputs.credentials_file_path }}
+          GOOGLE_APPLICATION_CREDENTIALS: ${{ steps.gcr-auth.outputs.credentials_file_path }}
       - if: inputs.enable_trivy == 'true'
         name: Upload Trivy scan results to GitHub Security tab
         uses: github/codeql-action/upload-sarif@v1

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -44,7 +44,7 @@ on:
         description: 'List of tags as key-value pair attributes'
         required: false
         type: string
-        default: 'default'
+        default: ''
       image_name:
         description: 'The name of the image'
         required: true

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -255,7 +255,6 @@ jobs:
         run: |
           docker pull ${{ inputs.image_registry }}/${{ inputs.image_organization }}/${{ inputs.image_name }}:${{ inputs.tag }}
           docker save -o vuln-image.tar ${{ inputs.image_registry }}/${{ inputs.image_organization }}/${{ inputs.image_name }}:${{ inputs.tag }}
-          
       - if: inputs.enable_trivy == 'true'
         name: Run Trivy vulnerability scanner
         uses: aquasecurity/trivy-action@master
@@ -267,8 +266,6 @@ jobs:
           ignore-unfixed: true
           vuln-type: 'os,library'
           severity: 'CRITICAL,HIGH'
-        env:
-          GOOGLE_APPLICATION_CREDENTIALS: ${{ steps.gcr-auth.outputs.credentials_file_path }}
       - if: inputs.enable_trivy == 'true'
         name: Upload Trivy scan results to GitHub Security tab
         uses: github/codeql-action/upload-sarif@v1

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -250,24 +250,24 @@ jobs:
       #     comment_tag: dockerTags
       
       # ## image scanning
-      # - if: inputs.enable_trivy == 'true'
-      #   name: Run Trivy vulnerability scanner
-      #   uses: aquasecurity/trivy-action@master
-      #   with:
-      #     image-ref: '${{ inputs.image_registry }}/${{ inputs.image_organization }}/${{ inputs.image_name }}:${{ inputs.tag }}'
-      #     format: 'sarif'
-      #     output: 'trivy-results.sarif'
-      #     exit-code: '0'
-      #     ignore-unfixed: true
-      #     vuln-type: 'os,library'
-      #     severity: 'CRITICAL,HIGH'
-      #   env:
-      #     GOOGLE_APPLICATION_CREDENTIALS: ${{ steps.auth.outputs.credentials_file_path }}
-      # - if: inputs.enable_trivy == 'true'
-      #   name: Upload Trivy scan results to GitHub Security tab
-      #   uses: github/codeql-action/upload-sarif@v1
-      #   with:
-      #     sarif_file: 'trivy-results.sarif'
+      - if: inputs.enable_trivy == 'true'
+        name: Run Trivy vulnerability scanner
+        uses: aquasecurity/trivy-action@master
+        with:
+          image-ref: '${{ inputs.image_registry }}/${{ inputs.image_organization }}/${{ inputs.image_name }}:${{ inputs.tag }}'
+          format: 'sarif'
+          output: 'trivy-results.sarif'
+          exit-code: '0'
+          ignore-unfixed: true
+          vuln-type: 'os,library'
+          severity: 'CRITICAL,HIGH'
+        env:
+          GOOGLE_APPLICATION_CREDENTIALS: ${{ steps.auth.outputs.credentials_file_path }}
+      - if: inputs.enable_trivy == 'true'
+        name: Upload Trivy scan results to GitHub Security tab
+        uses: github/codeql-action/upload-sarif@v1
+        with:
+          sarif_file: 'trivy-results.sarif'
 
 
 # Example Usage


### PR DESCRIPTION
Proof of concept here:

https://github.com/radixdlt/babylon-nginx/actions/runs/4344336992

https://github.com/radixdlt/babylon-nginx/security/code-scanning?query=is%3Aopen+pr%3A14

Note: this also fixes a bug with wrong default tags when only specifying `tag` and not `tags`
