### PR TITLE
Fix/default tag type

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -221,7 +221,7 @@ jobs:
         with:
           images: ${{ inputs.image_registry }}/${{ inputs.image_organization }}/${{ inputs.image_name }}
           tags: 
-            type=raw,value=${{ inputs.tag }}
+            type=raw,value=${{ inputs.tag }},enable=${{ inputs.tag != '' }}
             ${{ inputs.tags }}
           flavor: |
             latest=false

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -220,7 +220,7 @@ jobs:
         uses: docker/metadata-action@57396166ad8aefe6098280995947635806a0e6ea
         with:
           images: ${{ inputs.image_registry }}/${{ inputs.image_organization }}/${{ inputs.image_name }}
-          tags: 
+          tags: |
             type=raw,value=${{ inputs.tag }},enable=${{ inputs.tag != '' }}
             ${{ inputs.tags }}
           flavor: |


### PR DESCRIPTION
When specifying the `tags` field only, the tag took part of the input string as the tag to push.

This ended up with images being pushed with an additional tag called `type`.