### PR TITLE
Rust coverage workflow

### DIFF
--- a/.github/workflows/rust-tests.yml
+++ b/.github/workflows/rust-tests.yml
@@ -1,0 +1,33 @@
+name: cargo-tests-with-cov
+
+on:
+  workflow_call:
+    inputs:
+      flags:
+        description: 'Cargo test flags'
+        required: false
+        default: ''
+        type: string
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    container:
+      image: 
+    steps:
+      - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9
+        with:
+          fetch-depth: 0
+      - name: Install grcov and llvm-tools-preview 
+        run: |
+          rustup component add llvm-tools-preview
+          cargo install grcov
+      - name: run tests
+        run: |
+          CARGO_INCREMENTAL=0 RUSTFLAGS='-Cinstrument-coverage' LLVM_PROFILE_FILE='cargo-test-%p-%m.profraw' cargo test ${{ inputs.flags }}
+          ls -la 
+      - name: Generate coverage
+        run: |
+          grcov . --binary-path target/debug/deps/ -s . -t html --branch --ignore-not-existing --ignore '../*' --ignore "/*" -o target/coverage/html
+          ls -la target/coverage/html
+

--- a/.github/workflows/rust-tests.yml
+++ b/.github/workflows/rust-tests.yml
@@ -12,8 +12,8 @@ on:
 jobs:
   build-and-push:
     runs-on: ubuntu-latest
-    container:
-      image: 
+    container: rust:1.70.0-bullseye
+      image:  
     steps:
       - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9
         with:

--- a/.github/workflows/rust-tests.yml
+++ b/.github/workflows/rust-tests.yml
@@ -22,6 +22,7 @@ jobs:
         run: |
           rustup component add llvm-tools-preview
           cargo install grcov
+          apt update && apt install -y build-essential cmake
       - name: run tests
         run: |
           CARGO_INCREMENTAL=0 RUSTFLAGS='-Cinstrument-coverage' LLVM_PROFILE_FILE='cargo-test-%p-%m.profraw' cargo test ${{ inputs.flags }}

--- a/.github/workflows/rust-tests.yml
+++ b/.github/workflows/rust-tests.yml
@@ -12,8 +12,8 @@ on:
 jobs:
   build-and-push:
     runs-on: ubuntu-latest
-    container: rust:1.70.0-bullseye
-      image:  
+    container:
+      image: rust:1.70.0-bullseye 
     steps:
       - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9
         with:


### PR DESCRIPTION
This is needed in order to run the tests within a rust container and make builds reproducibles