### PR TITLE
add a sanity check when building docker images

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -157,6 +157,11 @@ on:
         required: false
         type: boolean
         default: false
+      sanity_check:
+        description: 'path to a script that can be used to sanity check the image built'
+        required: false
+        type: string
+        default: ''
     outputs:
       tags:
         description: "The tags from metadata-action"
@@ -362,7 +367,13 @@ jobs:
           snyk -v
           snyk auth ${{ env.SNYK_TOKEN }}
           snyk container test ${{ inputs.image_registry }}/${{ inputs.image_organization }}/${{ inputs.image_name }}:${{ steps.default_docker_tag.outputs.default_tag }} --file=${{ inputs.dockerfile }} --severity-threshold=critical --target-reference=${{ inputs.snyk_target_ref }}
-      
+
+        if: inputs.sanity_check != ''
+        name: Sanity check
+        shell: bash
+        run: |
+          set -ex
+          ${{ inputs.sanity_check }}
       # ## image scanning
       # - if: inputs.enable_trivy == 'true'
       #   name: Generate tarball from image

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -368,7 +368,7 @@ jobs:
           snyk auth ${{ env.SNYK_TOKEN }}
           snyk container test ${{ inputs.image_registry }}/${{ inputs.image_organization }}/${{ inputs.image_name }}:${{ steps.default_docker_tag.outputs.default_tag }} --file=${{ inputs.dockerfile }} --severity-threshold=critical --target-reference=${{ inputs.snyk_target_ref }}
 
-        if: inputs.sanity_check != ''
+      - if: inputs.sanity_check != ''
         name: Sanity check
         shell: bash
         run: |


### PR DESCRIPTION
here's an example of usage: https://github.com/radixdlt/radixdlt-scrypto/blob/chore/simulator-image/.github/workflows/simulator.yml#L34

This will allow us to test docker images right after building them, without needing to deploy. 
babylon-node would be another repo where we can benefit from this 