### PR TITLE
make cache optional

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -359,7 +359,7 @@ jobs:
           target: ${{ inputs.target }}
           provenance: ${{ inputs.provenance }}
           sbom: ${{ inputs.with_sbom }}
-      - if: steps.export_cache_calc.outputs.export_cache_flag
+      - if: steps.export_cache_calc.outputs.export_cache_flag == true
         name: Save Image cache
         id: cache-image-save
         uses: actions/cache/save@v3

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -329,7 +329,7 @@ jobs:
       - name: Export Cache caluclation
         id: export_cache
         run: |
-          export EXPORT_CACHE_FLAG=${{ github.ref == 'refs/heads/master' || github.ref == 'refs/heads/develop' || startsWith(github.ref, 'refs/heads/release') }}
+          export EXPORT_CACHE_FLAG=${{ github.ref == 'refs/heads/main' || github.ref == 'refs/heads/master' || github.ref == 'refs/heads/develop' || startsWith(github.ref, 'refs/heads/release') }}
           echo "EXPORT_CACHE_FLAG=$EXPORT_CACHE_FLAG" >> $GITHUB_OUTPUT
       - name: Restore cached image-cache
         id: cache-image-restore
@@ -359,7 +359,7 @@ jobs:
           target: ${{ inputs.target }}
           provenance: ${{ inputs.provenance }}
           sbom: ${{ inputs.with_sbom }}
-      - if: github.ref == 'refs/heads/master' || github.ref == 'refs/heads/develop' || startsWith(github.ref, 'refs/heads/release')
+      - if: steps.export_cache.outputs.EXPORT_CACHE_FLAG
         name: Save Image cache
         id: cache-image-save
         uses: actions/cache/save@v3

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -326,7 +326,11 @@ jobs:
         run: |
           echo "default_tag=${{ fromJSON(steps.metadata.outputs.json).labels['org.opencontainers.image.version'] }}"
           echo "default_tag=${{ fromJSON(steps.metadata.outputs.json).labels['org.opencontainers.image.version'] }}" >> $GITHUB_OUTPUT
-          
+      - name: Export Cache caluclation
+        id: export_cache
+        run: |
+          export EXPORT_CACHE_FLAG=${{ github.ref == 'refs/heads/master' || github.ref == 'refs/heads/develop' || startsWith(github.ref, 'refs/heads/release') }}
+          echo "EXPORT_CACHE_FLAG=$EXPORT_CACHE_FLAG" >> $GITHUB_OUTPUT
       - name: Restore cached image-cache
         id: cache-image-restore
         uses: actions/cache/restore@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8
@@ -347,7 +351,7 @@ jobs:
             type=local,src=/tmp/outputs/cache/docker
             ${{ inputs.use_gh_remote_cache && format('type=registry,ref=ghcr.io/radixdlt/{0}-cache:{1}-{2}',inputs.image_name, steps.default_docker_tag.outputs.default_tag, inputs.cache_tag_suffix) || '' }}
           cache-to: |
-            type=local,dest=/tmp/outputs/cache/docker,mode=max
+            ${{ steps.export_cache.outputs.EXPORT_CACHE_FLAG && 'type=local,dest=/tmp/outputs/cache/docker,mode=max' || '' }}
             ${{ inputs.use_gh_remote_cache && format('type=registry,ref=ghcr.io/radixdlt/{0}-cache:{1}-{2},mode=max',inputs.image_name, steps.default_docker_tag.outputs.default_tag, inputs.cache_tag_suffix) || '' }}
           tags: ${{ steps.metadata.outputs.tags }}
           labels: ${{ steps.metadata.outputs.labels }}

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -359,6 +359,7 @@ jobs:
           target: ${{ inputs.target }}
           provenance: ${{ inputs.provenance }}
           sbom: ${{ inputs.with_sbom }}
+          no-cache: true
       - if: steps.export_cache_calc.outputs.export_cache_flag == true
         name: Save Image cache
         id: cache-image-save

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -327,10 +327,10 @@ jobs:
           echo "default_tag=${{ fromJSON(steps.metadata.outputs.json).labels['org.opencontainers.image.version'] }}"
           echo "default_tag=${{ fromJSON(steps.metadata.outputs.json).labels['org.opencontainers.image.version'] }}" >> $GITHUB_OUTPUT
       - name: Export Cache caluclation
-        id: export_cache
+        id: export_cache_calc
         run: |
-          export EXPORT_CACHE_FLAG=${{ github.ref == 'refs/heads/main' || github.ref == 'refs/heads/master' || github.ref == 'refs/heads/develop' || startsWith(github.ref, 'refs/heads/release') }}
-          echo "EXPORT_CACHE_FLAG=$EXPORT_CACHE_FLAG" >> $GITHUB_OUTPUT
+          export export_cache_flag=${{ github.ref == 'refs/heads/main' || github.ref == 'refs/heads/master' || github.ref == 'refs/heads/develop' || startsWith(github.ref, 'refs/heads/release') }}
+          echo "export_cache_flag=$export_cache_flag" >> $GITHUB_OUTPUT
       - name: Restore cached image-cache
         id: cache-image-restore
         uses: actions/cache/restore@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8
@@ -351,7 +351,7 @@ jobs:
             type=local,src=/tmp/outputs/cache/docker
             ${{ inputs.use_gh_remote_cache && format('type=registry,ref=ghcr.io/radixdlt/{0}-cache:{1}-{2}',inputs.image_name, steps.default_docker_tag.outputs.default_tag, inputs.cache_tag_suffix) || '' }}
           cache-to: |
-            ${{ steps.export_cache.outputs.EXPORT_CACHE_FLAG && 'type=local,dest=/tmp/outputs/cache/docker,mode=max' || '' }}
+            ${{ steps.export_cache_calc.outputs.export_cache_flag && 'type=local,dest=/tmp/outputs/cache/docker,mode=max' || '' }}
             ${{ inputs.use_gh_remote_cache && format('type=registry,ref=ghcr.io/radixdlt/{0}-cache:{1}-{2},mode=max',inputs.image_name, steps.default_docker_tag.outputs.default_tag, inputs.cache_tag_suffix) || '' }}
           tags: ${{ steps.metadata.outputs.tags }}
           labels: ${{ steps.metadata.outputs.labels }}
@@ -359,7 +359,7 @@ jobs:
           target: ${{ inputs.target }}
           provenance: ${{ inputs.provenance }}
           sbom: ${{ inputs.with_sbom }}
-      - if: steps.export_cache.outputs.EXPORT_CACHE_FLAG
+      - if: steps.export_cache_calc.outputs.export_cache_flag
         name: Save Image cache
         id: cache-image-save
         uses: actions/cache/save@v3

--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -351,7 +351,7 @@ jobs:
             type=local,src=/tmp/outputs/cache/docker
             ${{ inputs.use_gh_remote_cache && format('type=registry,ref=ghcr.io/radixdlt/{0}-cache:{1}-{2}',inputs.image_name, steps.default_docker_tag.outputs.default_tag, inputs.cache_tag_suffix) || '' }}
           cache-to: |
-            ${{ steps.export_cache_calc.outputs.export_cache_flag && 'type=local,dest=/tmp/outputs/cache/docker,mode=max' || '' }}
+            ${{ steps.export_cache_calc.outputs.export_cache_flag == 'true' && 'type=local,dest=/tmp/outputs/cache/docker,mode=max' || '' }}
             ${{ inputs.use_gh_remote_cache && format('type=registry,ref=ghcr.io/radixdlt/{0}-cache:{1}-{2},mode=max',inputs.image_name, steps.default_docker_tag.outputs.default_tag, inputs.cache_tag_suffix) || '' }}
           tags: ${{ steps.metadata.outputs.tags }}
           labels: ${{ steps.metadata.outputs.labels }}
@@ -359,7 +359,6 @@ jobs:
           target: ${{ inputs.target }}
           provenance: ${{ inputs.provenance }}
           sbom: ${{ inputs.with_sbom }}
-          no-cache: true
       - if: steps.export_cache_calc.outputs.export_cache_flag == true
         name: Save Image cache
         id: cache-image-save


### PR DESCRIPTION
As part of an initiative to only store the cache of main/master branches in the github-cache, I missed to remove the production of the cache on other branches. Now the cache was created but not uploaded. This essentially wasted a minute or two on every build. 

This PR aims to straighten this out. 