### PR TITLE
[DO-2496] Switch Tailscale auth to oauth

### DIFF
--- a/tailnet/action.yml
+++ b/tailnet/action.yml
@@ -30,3 +30,4 @@ runs:
       with:
         oauth-client-id: ${{ env.TAILSCALE_CLIENT_ID }}
         oauth-secret: ${{ env.TAILSCALE_CLIENT_SECRET }}
+        tags: tag:ci

--- a/tailnet/action.yml
+++ b/tailnet/action.yml
@@ -28,4 +28,5 @@ runs:
     - name: "Connect to Tailnet"
       uses: RDXWorks-actions/github-action@main
       with:
-        authkey: ${{ env.TAILSCALE_AUTHKEY }}
+        oauth-client-id: ${{ env.TAILSCALE_CLIENT_ID }}
+        oauth-secret: ${{ env.TAILSCALE_CLIENT_SECRET }}


### PR DESCRIPTION
Tailscale github action now supports OAuth. By switching to OAuth there won't be need to rotate static Auth Keys