### PR TITLE
Skip session tagging on docker builds

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -227,6 +227,7 @@ jobs:
         with:
           role-to-assume: arn:aws:iam::308190735829:role/gh-common-secrets-read-access
           aws-region: eu-west-2
+          role-skip-session-tagging: true
       # This is version v1.0.4
       # https://github.com/aws-actions/configure-aws-credentials/releases/tag/v1.0.4
       - name: Read secrets from AWS Secrets Manager into environment variables (Private)
@@ -250,6 +251,7 @@ jobs:
         with:
           role-to-assume: ${{ secrets.role_to_assume }}
           aws-region: eu-west-2
+          role-skip-session-tagging: true
       - if: inputs.enable_dockerhub == 'true'
         name: Read secrets from AWS Secrets Manager into environment variables (Public)
         uses: RDXWorks-actions/aws-secretsmanager-get-secrets@main


### PR DESCRIPTION
Fixes issue with self-hosted runners: https://github.com/radixdlt/radixdlt-scrypto/actions/runs/20461368933/job/58794723788